### PR TITLE
Wrap code in a check for whether $.validator is defined

### DIFF
--- a/dist/unobtrusive-bootstrap.js
+++ b/dist/unobtrusive-bootstrap.js
@@ -1,23 +1,28 @@
 (function ($) {
-    var defaultOptions = {
-        validClass: 'is-valid',
-        errorClass: 'is-invalid',
-        highlight: function (element, errorClass, validClass) {
-            $(element)
-                .removeClass(validClass)
-                .addClass(errorClass);
-        },
-        unhighlight: function (element, errorClass, validClass) {
-            $(element)
-                .removeClass(errorClass)
-                .addClass(validClass);
-        }
-    };
+    if($.validator && $.validator.unobtrusive){
+        var defaultOptions = {
+            validClass: 'is-valid',
+            errorClass: 'is-invalid',
+            highlight: function (element, errorClass, validClass) {
+                $(element)
+                    .removeClass(validClass)
+                    .addClass(errorClass);
+            },
+            unhighlight: function (element, errorClass, validClass) {
+                $(element)
+                    .removeClass(errorClass)
+                    .addClass(validClass);
+            }
+        };
 
-    $.validator.setDefaults(defaultOptions);
+        $.validator.setDefaults(defaultOptions);
 
-    $.validator.unobtrusive.options = {
-        errorClass: defaultOptions.errorClass,
-        validClass: defaultOptions.validClass,
-    };
+        $.validator.unobtrusive.options = {
+            errorClass: defaultOptions.errorClass,
+            validClass: defaultOptions.validClass,
+        };
+    }
+    else {
+        console.warn('$.validator is not defined. Please load this library **after** loading jquery.validate.js and jquery.validate.unobtrusive.js');
+    }
 })(jQuery);


### PR DESCRIPTION
This will generate a warning if the validation and unobtrusive validation libraries have not been loaded, rather than causing an error.