### PR TITLE
$element is undefined / $error is undefined fix

### DIFF
--- a/dist/unobtrusive-bootstrap.js
+++ b/dist/unobtrusive-bootstrap.js
@@ -24,10 +24,10 @@
             errorPlacement: function (error, element) {
                 error.addClass('invalid-feedback');
 
-                if ($element.next().is(".input-group-append")) {
-                    $error.insertAfter($element.next());
+                if (element.next().is(".input-group-append")) {
+                    error.insertAfter(element.next());
                 } else {
-                    $error.insertAfter($element);
+                    error.insertAfter(element);
                 }
             }
         };


### PR DESCRIPTION
I picked up an error when pulling the latest version, v2.1.0, under the options/errorPlacement method. The issue here is both $element and $error aren't defined and need merely to be renamed to reference the local variables.

Hope this helps